### PR TITLE
fix: Don't allow `lcobucci/jwt` 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "illuminate/http": "^8",
         "illuminate/support": "^8",
         "lcobucci/clock": "^2",
-        "lcobucci/jwt": "^4",
+        "lcobucci/jwt": "~4.1",
         "cse/helpers-session": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
This package uses the `StrictValidAt` validation constraint which is
only available since the version `4.1` of the jwt package.
Or this version of the jwt package relies on the sodium PHP extension.
If this extension is not installed on the client environment, then the
version `4.0` of the jwt package which, does not provide the requested
class, is installed by default.

Signed-off-by: Eric Villard <dev@eviweb.fr>

**List of common tasks a pull request require complete**
- [ ] Changelog entry is added or the pull request don't alter library's functionality
